### PR TITLE
fix a compilation error thrown by icc

### DIFF
--- a/src/utils/Numerics.cc
+++ b/src/utils/Numerics.cc
@@ -1191,7 +1191,7 @@ int LUDecomposition(PPflt a, const int n, Pint indx, int& d)
     d = 1;
     for(i=0; i<n; i++) {
         big = 0.;
-	for(j=0; j<n; j++) big = std::max(double(big), fabs(a[i][j]));
+	for(j=0; j<n; j++) big = std::max(double(big), double(fabs(a[i][j])));
         if(big==0.) return Numerics_message("LUDecomposition: singular matrix");
 	vv[i] = 1./big;
     }


### PR DESCRIPTION
I got the below error msg when using the Intel compiler. This is just a quick fix.

`galpy/actionAngle/actionAngleTorus_c_ext/torus/src/utils/Numerics.cc(1194): error: no instance of overloaded function "std::max" matches the argument list
            argument types are: (double, float)
  	for(j=0; j<n; j++) big = std::max(double(big), fabs(a[i][j]));
  	                         ^
`